### PR TITLE
Ignore dependabot in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+      - dependabot/**
 
 jobs:
   test:


### PR DESCRIPTION
As https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544 outlines, running tests with secrets on dependabot PRs can be a potential security hazard. This PR stops the tests from running on dependabot branches (they cannot access the secrets anyway, but the PR prevents the tests from failing immediately on those branches).